### PR TITLE
Add balldontlie NBA provider adapter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,9 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
   },
   {
     ignores: ["dist/", "node_modules/"],

--- a/src/providers/balldontlie/adapter.test.ts
+++ b/src/providers/balldontlie/adapter.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BalldontlieAdapter } from "./adapter.js";
+import { BdlClient } from "./client.js";
+import type { BdlPlayer, BdlTeam, BdlGame, BdlStats, BdlListResponse, BdlMeta } from "./types.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const LAKERS: BdlTeam = {
+  id: 14,
+  conference: "West",
+  division: "Pacific",
+  city: "Los Angeles",
+  name: "Lakers",
+  full_name: "Los Angeles Lakers",
+  abbreviation: "LAL",
+};
+
+const CELTICS: BdlTeam = {
+  id: 2,
+  conference: "East",
+  division: "Atlantic",
+  city: "Boston",
+  name: "Celtics",
+  full_name: "Boston Celtics",
+  abbreviation: "BOS",
+};
+
+const LEBRON: BdlPlayer = {
+  id: 237,
+  first_name: "LeBron",
+  last_name: "James",
+  position: "F",
+  height: "6-9",
+  weight: "250",
+  jersey_number: "23",
+  college: "None",
+  country: "USA",
+  draft_year: 2003,
+  draft_round: 1,
+  draft_number: 1,
+  team: LAKERS,
+};
+
+const FREE_AGENT: BdlPlayer = {
+  id: 999,
+  first_name: "No",
+  last_name: "Team",
+  position: "",
+  height: null,
+  weight: null,
+  jersey_number: null,
+  college: null,
+  country: null,
+  draft_year: null,
+  draft_round: null,
+  draft_number: null,
+  team: null,
+};
+
+const GAME: BdlGame = {
+  id: 1001,
+  date: "2024-01-15",
+  season: 2023,
+  status: "Final",
+  period: 4,
+  time: " ",
+  postseason: false,
+  home_team_score: 115,
+  visitor_team_score: 108,
+  home_team: LAKERS,
+  visitor_team: CELTICS,
+};
+
+const SCHEDULED_GAME: BdlGame = {
+  ...GAME,
+  id: 1002,
+  status: "Scheduled",
+  home_team_score: 0,
+  visitor_team_score: 0,
+};
+
+const STAT: BdlStats = {
+  id: 5001,
+  min: "32:10",
+  fgm: 12,
+  fga: 20,
+  fg3m: 2,
+  fg3a: 5,
+  ftm: 6,
+  fta: 7,
+  oreb: 1,
+  dreb: 7,
+  reb: 8,
+  ast: 10,
+  stl: 2,
+  blk: 1,
+  turnover: 3,
+  pf: 2,
+  pts: 32,
+  fg_pct: 0.6,
+  fg3_pct: 0.4,
+  ft_pct: 0.857,
+  player: LEBRON,
+  team: LAKERS,
+  game: GAME,
+};
+
+function meta(total: number): BdlMeta {
+  return { total_pages: 1, current_page: 1, next_page: null, per_page: 100, total_count: total };
+}
+
+function listResponse<T>(data: T[]): BdlListResponse<T> {
+  return { data, meta: meta(data.length) };
+}
+
+// ─── BdlClient (unit) ──────────────────────────────────────────────────────────
+
+describe("BdlClient", () => {
+  function makeMockFetch(responses: Record<string, unknown>) {
+    return vi.fn(async (url: string | URL) => {
+      const path = new URL(url.toString()).pathname;
+      const body = responses[path] ?? { data: [], meta: meta(0) };
+      return {
+        ok: true,
+        json: async () => body,
+        text: async () => "",
+      };
+    });
+  }
+
+  it("calls /players and returns data", async () => {
+    const mockFetch = makeMockFetch({ "/v1/players": listResponse([LEBRON]) });
+    const client = new BdlClient({ fetch: mockFetch as unknown as typeof fetch, rateLimitMs: 0 });
+    const players = await client.getPlayers();
+    expect(players).toHaveLength(1);
+    expect(players[0].id).toBe(237);
+  });
+
+  it("calls /teams and returns data", async () => {
+    const mockFetch = makeMockFetch({ "/v1/teams": listResponse([LAKERS, CELTICS]) });
+    const client = new BdlClient({ fetch: mockFetch as unknown as typeof fetch, rateLimitMs: 0 });
+    const teams = await client.getTeams();
+    expect(teams).toHaveLength(2);
+  });
+
+  it("calls /games with season param", async () => {
+    const mockFetch = makeMockFetch({ "/v1/games": listResponse([GAME]) });
+    const client = new BdlClient({ fetch: mockFetch as unknown as typeof fetch, rateLimitMs: 0 });
+    const games = await client.getGames(2023);
+    expect(games).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("seasons=2023"),
+      expect.any(Object)
+    );
+  });
+
+  it("sends Authorization header when apiKey is set", async () => {
+    const mockFetch = makeMockFetch({ "/v1/teams": listResponse([]) });
+    const client = new BdlClient({
+      apiKey: "test-key",
+      fetch: mockFetch as unknown as typeof fetch,
+      rateLimitMs: 0,
+    });
+    await client.getTeams();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "test-key" }) })
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: false,
+      status: 429,
+      text: async () => "rate limited",
+      json: async () => ({}),
+    }));
+    const client = new BdlClient({ fetch: mockFetch as unknown as typeof fetch, rateLimitMs: 0 });
+    await expect(client.getTeams()).rejects.toThrow("429");
+  });
+
+  it("paginates through multiple pages", async () => {
+    let page = 0;
+    const mockFetch = vi.fn(async () => {
+      page++;
+      const isLastPage = page >= 2;
+      return {
+        ok: true,
+        text: async () => "",
+        json: async () => ({
+          data: [LAKERS],
+          meta: {
+            total_pages: 2,
+            current_page: page,
+            next_page: isLastPage ? null : page + 1,
+            per_page: 100,
+            total_count: 2,
+          },
+        }),
+      };
+    });
+    const client = new BdlClient({ fetch: mockFetch as unknown as typeof fetch, rateLimitMs: 0 });
+    const teams = await client.getTeams();
+    expect(teams).toHaveLength(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── BalldontlieAdapter ────────────────────────────────────────────────────────
+
+describe("BalldontlieAdapter", () => {
+  let adapter: BalldontlieAdapter;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    adapter = new BalldontlieAdapter({ fetch: mockFetch as unknown as typeof fetch, rateLimitMs: 0 });
+  });
+
+  function setupMock(responses: Record<string, unknown>) {
+    mockFetch.mockImplementation(async (url: string) => {
+      const path = new URL(url).pathname;
+      const body = responses[path] ?? { data: [], meta: meta(0) };
+      return { ok: true, json: async () => body, text: async () => "" };
+    });
+  }
+
+  // ── provider metadata ──
+
+  it("has provider = 'balldontlie'", () => {
+    expect(adapter.provider).toBe("balldontlie");
+  });
+
+  it("supports only nba", () => {
+    expect(adapter.supportedSports).toEqual(["nba"]);
+  });
+
+  // ── fetchPlayers ──
+
+  describe("fetchPlayers", () => {
+    it("maps players to RawPlayerData", async () => {
+      setupMock({ "/v1/players": listResponse([LEBRON]) });
+      const players = await adapter.fetchPlayers("nba", "2023-24");
+      expect(players).toHaveLength(1);
+      expect(players[0].externalId).toBe("237");
+      expect(players[0].name).toBe("LeBron James");
+      expect(players[0].team).toBe("LAL");
+      expect(players[0].position).toBe("F");
+    });
+
+    it("uses FA for players with no team", async () => {
+      setupMock({ "/v1/players": listResponse([FREE_AGENT]) });
+      const players = await adapter.fetchPlayers("nba", "2023-24");
+      expect(players[0].team).toBe("FA");
+    });
+
+    it("uses Unknown for empty position", async () => {
+      setupMock({ "/v1/players": listResponse([FREE_AGENT]) });
+      const players = await adapter.fetchPlayers("nba", "2023-24");
+      expect(players[0].position).toBe("Unknown");
+    });
+
+    it("preserves raw response", async () => {
+      setupMock({ "/v1/players": listResponse([LEBRON]) });
+      const players = await adapter.fetchPlayers("nba", "2023-24");
+      expect((players[0].raw as typeof LEBRON).id).toBe(237);
+    });
+  });
+
+  // ── fetchTeams ──
+
+  describe("fetchTeams", () => {
+    it("maps teams to RawTeamData", async () => {
+      setupMock({ "/v1/teams": listResponse([LAKERS, CELTICS]) });
+      const teams = await adapter.fetchTeams("nba", "2023-24");
+      expect(teams).toHaveLength(2);
+      expect(teams[0].externalId).toBe("14");
+      expect(teams[0].name).toBe("Los Angeles Lakers");
+      expect(teams[0].abbreviation).toBe("LAL");
+    });
+  });
+
+  // ── fetchGames ──
+
+  describe("fetchGames", () => {
+    it("maps finished games to RawGameData", async () => {
+      setupMock({ "/v1/games": listResponse([GAME]) });
+      const games = await adapter.fetchGames("nba", "2023-24");
+      expect(games).toHaveLength(1);
+      expect(games[0].externalId).toBe("1001");
+      expect(games[0].homeTeam).toBe("LAL");
+      expect(games[0].awayTeam).toBe("BOS");
+      expect(games[0].status).toBe("final");
+      expect(games[0].scheduledAt).toBe("2024-01-15");
+    });
+
+    it("maps scheduled games with correct status", async () => {
+      setupMock({ "/v1/games": listResponse([SCHEDULED_GAME]) });
+      const games = await adapter.fetchGames("nba", "2023-24");
+      expect(games[0].status).toBe("scheduled");
+    });
+
+    it("parses season year from 'YYYY-YY' format", async () => {
+      setupMock({ "/v1/games": listResponse([]) });
+      await adapter.fetchGames("nba", "2023-24");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("seasons=2023"),
+        expect.any(Object)
+      );
+    });
+
+    it("handles single-year season format", async () => {
+      setupMock({ "/v1/games": listResponse([]) });
+      await adapter.fetchGames("nba", "2024");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("seasons=2024"),
+        expect.any(Object)
+      );
+    });
+  });
+
+  // ── fetchPlayerStats ──
+
+  describe("fetchPlayerStats", () => {
+    it("maps stats to RawPlayerStatsData", async () => {
+      setupMock({ "/v1/stats": listResponse([STAT]) });
+      const stats = await adapter.fetchPlayerStats("nba", "2023-24");
+      expect(stats).toHaveLength(1);
+      expect(stats[0].playerExternalId).toBe("237");
+      expect(stats[0].gameExternalId).toBe("1001");
+      expect(stats[0].stats.pts).toBe(32);
+      expect(stats[0].stats.ast).toBe(10);
+      expect(stats[0].stats.reb).toBe(8);
+    });
+
+    it("coerces null stats to 0", async () => {
+      const nullStat = { ...STAT, pts: null, reb: null, ast: null };
+      setupMock({ "/v1/stats": listResponse([nullStat]) });
+      const stats = await adapter.fetchPlayerStats("nba", "2023-24");
+      expect(stats[0].stats.pts).toBe(0);
+      expect(stats[0].stats.reb).toBe(0);
+      expect(stats[0].stats.ast).toBe(0);
+    });
+
+    it("paginates through all stats pages", async () => {
+      let page = 0;
+      mockFetch.mockImplementation(async () => {
+        page++;
+        const isLastPage = page >= 2;
+        return {
+          ok: true,
+          text: async () => "",
+          json: async () => ({
+            data: [STAT],
+            meta: {
+              total_pages: 2,
+              current_page: page,
+              next_page: isLastPage ? null : page + 1,
+              per_page: 100,
+              total_count: 2,
+            },
+          }),
+        };
+      });
+      const stats = await adapter.fetchPlayerStats("nba", "2023-24");
+      expect(stats).toHaveLength(2);
+    });
+  });
+});
+
+// ─── Provider registry ────────────────────────────────────────────────────────
+
+describe("provider registry", () => {
+  it("registers and retrieves an adapter", async () => {
+    const { registerAdapter, getAdapter, clearAdapters } = await import("../index.js");
+    clearAdapters();
+    const adapter = new BalldontlieAdapter({ rateLimitMs: 0 });
+    registerAdapter(adapter);
+    expect(getAdapter("balldontlie")).toBe(adapter);
+    clearAdapters();
+  });
+
+  it("returns null for unregistered provider", async () => {
+    const { getAdapter, clearAdapters } = await import("../index.js");
+    clearAdapters();
+    expect(getAdapter("espn")).toBeNull();
+  });
+
+  it("lists all registered adapters", async () => {
+    const { registerAdapter, listAdapters, clearAdapters } = await import("../index.js");
+    clearAdapters();
+    registerAdapter(new BalldontlieAdapter({ rateLimitMs: 0 }));
+    expect(listAdapters()).toHaveLength(1);
+    clearAdapters();
+  });
+});

--- a/src/providers/balldontlie/adapter.ts
+++ b/src/providers/balldontlie/adapter.ts
@@ -1,0 +1,127 @@
+import type {
+  ProviderAdapter,
+  DataProvider,
+  Sport,
+  RawPlayerData,
+  RawTeamData,
+  RawGameData,
+  RawPlayerStatsData,
+} from "../../core/types.js";
+import { BdlClient, type BdlClientOptions } from "./client.js";
+import type { BdlGame, BdlPlayer, BdlTeam } from "./types.js";
+
+const GAME_STATUS_MAP: Record<string, string> = {
+  Final: "final",
+  "In Progress": "in_progress",
+  Scheduled: "scheduled",
+};
+
+function mapGameStatus(raw: string): string {
+  return GAME_STATUS_MAP[raw] ?? "scheduled";
+}
+
+function mapPlayer(p: BdlPlayer): RawPlayerData {
+  const position = p.position?.trim() || "Unknown";
+  const team = p.team?.abbreviation ?? "FA";
+  return {
+    externalId: String(p.id),
+    name: `${p.first_name} ${p.last_name}`.trim(),
+    team,
+    position,
+    raw: p as unknown as Record<string, unknown>,
+  };
+}
+
+function mapTeam(t: BdlTeam): RawTeamData {
+  return {
+    externalId: String(t.id),
+    name: t.full_name,
+    abbreviation: t.abbreviation,
+    raw: t as unknown as Record<string, unknown>,
+  };
+}
+
+function mapGame(g: BdlGame): RawGameData {
+  const score =
+    g.status === "Final"
+      ? { home: g.home_team_score, away: g.visitor_team_score }
+      : null;
+
+  return {
+    externalId: String(g.id),
+    homeTeam: g.home_team.abbreviation,
+    awayTeam: g.visitor_team.abbreviation,
+    scheduledAt: g.date,
+    status: mapGameStatus(g.status),
+    raw: { ...g, score } as unknown as Record<string, unknown>,
+  };
+}
+
+export class BalldontlieAdapter implements ProviderAdapter {
+  readonly provider: DataProvider = "balldontlie";
+  readonly supportedSports: Sport[] = ["nba"];
+
+  private client: BdlClient;
+
+  constructor(options: BdlClientOptions = {}) {
+    this.client = new BdlClient(options);
+  }
+
+  async fetchPlayers(_sport: Sport, _season: string): Promise<RawPlayerData[]> {
+    const players = await this.client.getPlayers();
+    return players.map(mapPlayer);
+  }
+
+  async fetchTeams(_sport: Sport, _season: string): Promise<RawTeamData[]> {
+    const teams = await this.client.getTeams();
+    return teams.map(mapTeam);
+  }
+
+  async fetchGames(_sport: Sport, season: string): Promise<RawGameData[]> {
+    const year = parseInt(season.split("-")[0], 10);
+    const games = await this.client.getGames(year);
+    return games.map(mapGame);
+  }
+
+  async fetchPlayerStats(_sport: Sport, season: string): Promise<RawPlayerStatsData[]> {
+    const year = parseInt(season.split("-")[0], 10);
+    const results: RawPlayerStatsData[] = [];
+    let page = 1;
+
+    while (true) {
+      const res = await this.client.getStats(year, page);
+      for (const s of res.data) {
+        results.push({
+          playerExternalId: String(s.player.id),
+          gameExternalId: String(s.game.id),
+          stats: {
+            min: s.min,
+            pts: s.pts ?? 0,
+            reb: s.reb ?? 0,
+            ast: s.ast ?? 0,
+            stl: s.stl ?? 0,
+            blk: s.blk ?? 0,
+            fgm: s.fgm ?? 0,
+            fga: s.fga ?? 0,
+            fg3m: s.fg3m ?? 0,
+            fg3a: s.fg3a ?? 0,
+            ftm: s.ftm ?? 0,
+            fta: s.fta ?? 0,
+            oreb: s.oreb ?? 0,
+            dreb: s.dreb ?? 0,
+            turnover: s.turnover ?? 0,
+            pf: s.pf ?? 0,
+            fg_pct: s.fg_pct ?? 0,
+            fg3_pct: s.fg3_pct ?? 0,
+            ft_pct: s.ft_pct ?? 0,
+          },
+          raw: s as unknown as Record<string, unknown>,
+        });
+      }
+      if (!res.meta.next_page) break;
+      page++;
+    }
+
+    return results;
+  }
+}

--- a/src/providers/balldontlie/client.ts
+++ b/src/providers/balldontlie/client.ts
@@ -1,0 +1,89 @@
+import type { BdlListResponse, BdlPlayer, BdlTeam, BdlGame, BdlStats } from "./types.js";
+
+export interface BdlClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  /** Minimum ms between requests to stay under 60 req/min rate limit */
+  rateLimitMs?: number;
+  /** Injectable fetch for testing */
+  fetch?: typeof globalThis.fetch;
+}
+
+export class BdlClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private rateLimitMs: number;
+  private fetchFn: typeof globalThis.fetch;
+  private lastRequestAt = 0;
+
+  constructor(options: BdlClientOptions = {}) {
+    this.apiKey = options.apiKey ?? process.env.BALLDONTLIE_API_KEY ?? "";
+    this.baseUrl = options.baseUrl ?? "https://api.balldontlie.io/v1";
+    this.rateLimitMs = options.rateLimitMs ?? 1100; // ~55 req/min safety margin
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  private async throttle(): Promise<void> {
+    const now = Date.now();
+    const elapsed = now - this.lastRequestAt;
+    if (this.lastRequestAt > 0 && elapsed < this.rateLimitMs) {
+      await new Promise((resolve) => setTimeout(resolve, this.rateLimitMs - elapsed));
+    }
+    this.lastRequestAt = Date.now();
+  }
+
+  private async get<T>(path: string, params: Record<string, string | number> = {}): Promise<T> {
+    await this.throttle();
+
+    const url = new URL(`${this.baseUrl}${path}`);
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, String(value));
+    }
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) headers["Authorization"] = this.apiKey;
+
+    const response = await this.fetchFn(url.toString(), { headers });
+    if (!response.ok) {
+      throw new Error(`balldontlie API error ${response.status}: ${await response.text()}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private async fetchAllPages<T>(
+    path: string,
+    params: Record<string, string | number> = {}
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+
+    while (true) {
+      const res = await this.get<BdlListResponse<T>>(path, { ...params, per_page: 100, page });
+      results.push(...res.data);
+      if (!res.meta.next_page) break;
+      page++;
+    }
+
+    return results;
+  }
+
+  async getPlayers(): Promise<BdlPlayer[]> {
+    return this.fetchAllPages<BdlPlayer>("/players");
+  }
+
+  async getTeams(): Promise<BdlTeam[]> {
+    return this.fetchAllPages<BdlTeam>("/teams");
+  }
+
+  async getGames(season: number): Promise<BdlGame[]> {
+    return this.fetchAllPages<BdlGame>("/games", { seasons: season });
+  }
+
+  async getStats(season: number, page = 1, perPage = 100): Promise<BdlListResponse<BdlStats>> {
+    return this.get<BdlListResponse<BdlStats>>("/stats", {
+      seasons: season,
+      per_page: perPage,
+      page,
+    });
+  }
+}

--- a/src/providers/balldontlie/types.ts
+++ b/src/providers/balldontlie/types.ts
@@ -1,0 +1,80 @@
+/** Raw types for the balldontlie API v1 responses (https://api.balldontlie.io/v1/) */
+
+export interface BdlTeam {
+  id: number;
+  conference: string;
+  division: string;
+  city: string;
+  name: string;
+  full_name: string;
+  abbreviation: string;
+}
+
+export interface BdlPlayer {
+  id: number;
+  first_name: string;
+  last_name: string;
+  position: string;
+  height: string | null;
+  weight: string | null;
+  jersey_number: string | null;
+  college: string | null;
+  country: string | null;
+  draft_year: number | null;
+  draft_round: number | null;
+  draft_number: number | null;
+  team: BdlTeam | null;
+}
+
+export interface BdlGame {
+  id: number;
+  date: string;
+  season: number;
+  status: string;
+  period: number;
+  time: string;
+  postseason: boolean;
+  home_team_score: number;
+  visitor_team_score: number;
+  home_team: BdlTeam;
+  visitor_team: BdlTeam;
+}
+
+export interface BdlStats {
+  id: number;
+  min: string;
+  fgm: number | null;
+  fga: number | null;
+  fg3m: number | null;
+  fg3a: number | null;
+  ftm: number | null;
+  fta: number | null;
+  oreb: number | null;
+  dreb: number | null;
+  reb: number | null;
+  ast: number | null;
+  stl: number | null;
+  blk: number | null;
+  turnover: number | null;
+  pf: number | null;
+  pts: number | null;
+  fg_pct: number | null;
+  fg3_pct: number | null;
+  ft_pct: number | null;
+  player: BdlPlayer;
+  team: BdlTeam;
+  game: BdlGame;
+}
+
+export interface BdlMeta {
+  total_pages: number;
+  current_page: number;
+  next_page: number | null;
+  per_page: number;
+  total_count: number;
+}
+
+export interface BdlListResponse<T> {
+  data: T[];
+  meta: BdlMeta;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,21 @@
+import type { ProviderAdapter, DataProvider } from "../core/types.js";
+
+const registry = new Map<DataProvider, ProviderAdapter>();
+
+export function registerAdapter(adapter: ProviderAdapter): void {
+  registry.set(adapter.provider, adapter);
+}
+
+export function getAdapter(provider: DataProvider): ProviderAdapter | null {
+  return registry.get(provider) ?? null;
+}
+
+export function listAdapters(): ProviderAdapter[] {
+  return Array.from(registry.values());
+}
+
+export function clearAdapters(): void {
+  registry.clear();
+}
+
+export { BalldontlieAdapter } from "./balldontlie/adapter.js";


### PR DESCRIPTION
Closes #3

## Changes
- `src/providers/balldontlie/types.ts` — raw API response types (`BdlPlayer`, `BdlTeam`, `BdlGame`, `BdlStats`, `BdlListResponse`)
- `src/providers/balldontlie/client.ts` — HTTP client with automatic pagination and 60 req/min rate limiting
- `src/providers/balldontlie/adapter.ts` — `BalldontlieAdapter` implementing `ProviderAdapter` for NBA; maps raw responses to `RawPlayerData`, `RawTeamData`, `RawGameData`, `RawPlayerStatsData`
- `src/providers/index.ts` — provider registry (`registerAdapter`, `getAdapter`, `listAdapters`)
- `eslint.config.js` — added `argsIgnorePattern: "^_"` so interface-required unused params can follow `_param` convention

## Design notes
- API key read from `BALLDONTLIE_API_KEY` env var; requests work without a key but rate limit is stricter
- `fetch` is injectable for tests (no real HTTP in CI)
- Season format `"YYYY-YY"` is parsed to extract the start year (e.g. `"2023-24"` → `2023`)
- Null stats fields are coerced to `0` in `fetchPlayerStats` to keep downstream math safe

## Tests
- 23 new tests covering `BdlClient` (pagination, auth header, error handling) and `BalldontlieAdapter` (all four fetch methods + edge cases) and provider registry
- All 48 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)